### PR TITLE
DD-1433. Use new dans-dataverse-client-lib parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <relativePath/>
     </parent>
     <artifactId>dans-java-utils</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <name>DANS Java Utility Classes</name>
     <inceptionYear>2021</inceptionYear>
     <scm>
@@ -42,6 +42,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
+            <version>0.21.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/nl/knaw/dans/lib/util/DataverseClientFactory.java
+++ b/src/main/java/nl/knaw/dans/lib/util/DataverseClientFactory.java
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.lib.util;
 
+import lombok.Getter;
+import lombok.Setter;
 import nl.knaw.dans.lib.dataverse.DataverseClient;
 import nl.knaw.dans.lib.dataverse.DataverseClientConfig;
 import org.slf4j.Logger;
@@ -22,6 +24,8 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 
+@Getter
+@Setter
 public class DataverseClientFactory {
     private static final Logger log = LoggerFactory.getLogger(DataverseClientFactory.class);
 
@@ -31,48 +35,20 @@ public class DataverseClientFactory {
     private int awaitLockStateMaxNumberOfRetries = 5;
     private int awaitLockStateMillisecondsBetweenRetries = 5000;
 
+    private int awaitIndexingMaxNumberOfRetries = 5;
+
+    private int awaitIndexingMillisecondsBetweenRetries = 5000;
+
+
     public DataverseClient build() {
-        DataverseClientConfig config = new DataverseClientConfig(baseUrl, apiKey, awaitLockStateMaxNumberOfRetries, awaitLockStateMillisecondsBetweenRetries, unblockKey);
+        DataverseClientConfig config = new DataverseClientConfig(
+            baseUrl,
+            apiKey,
+            awaitLockStateMaxNumberOfRetries,
+            awaitLockStateMillisecondsBetweenRetries,
+            awaitIndexingMaxNumberOfRetries,
+            awaitIndexingMillisecondsBetweenRetries,
+            unblockKey);
         return new DataverseClient(config);
-    }
-
-    public URI getBaseUrl() {
-        return baseUrl;
-    }
-
-    public void setBaseUrl(URI baseUrl) {
-        this.baseUrl = baseUrl;
-    }
-
-    public String getApiKey() {
-        return apiKey;
-    }
-
-    public void setApiKey(String apiKey) {
-        this.apiKey = apiKey;
-    }
-
-    public String getUnblockKey() {
-        return unblockKey;
-    }
-
-    public void setUnblockKey(String unblockKey) {
-        this.unblockKey = unblockKey;
-    }
-
-    public int getAwaitLockStateMaxNumberOfRetries() {
-        return awaitLockStateMaxNumberOfRetries;
-    }
-
-    public void setAwaitLockStateMaxNumberOfRetries(int awaitLockStateMaxNumberOfRetries) {
-        this.awaitLockStateMaxNumberOfRetries = awaitLockStateMaxNumberOfRetries;
-    }
-
-    public int getAwaitLockStateMillisecondsBetweenRetries() {
-        return awaitLockStateMillisecondsBetweenRetries;
-    }
-
-    public void setAwaitLockStateMillisecondsBetweenRetries(int awaitLockStateMillisecondsBetweenRetries) {
-        this.awaitLockStateMillisecondsBetweenRetries = awaitLockStateMillisecondsBetweenRetries;
     }
 }

--- a/src/main/java/nl/knaw/dans/lib/util/DataverseClientFactory.java
+++ b/src/main/java/nl/knaw/dans/lib/util/DataverseClientFactory.java
@@ -32,13 +32,10 @@ public class DataverseClientFactory {
     private URI baseUrl;
     private String apiKey;
     private String unblockKey;
-    private int awaitLockStateMaxNumberOfRetries = 5;
-    private int awaitLockStateMillisecondsBetweenRetries = 5000;
-
-    private int awaitIndexingMaxNumberOfRetries = 5;
-
-    private int awaitIndexingMillisecondsBetweenRetries = 5000;
-
+    private int awaitLockStateMaxNumberOfRetries = 30;
+    private int awaitLockStateMillisecondsBetweenRetries = 500;
+    private int awaitIndexingMaxNumberOfRetries = 15;
+    private int awaitIndexingMillisecondsBetweenRetries = 1000;
 
     public DataverseClient build() {
         DataverseClientConfig config = new DataverseClientConfig(


### PR DESCRIPTION
Fixes DD-1433

# Description of changes
* Set the new `DataverseClientConfig` parameters `awaitIndexingMaxNumberOfRetries` and `awaitIndexingMillisecondsBetweenRetries`.
* Small refactoring: using Lombok `@Setter` and `@Getter` annotations.

# Related PRs 
* https://github.com/DANS-KNAW/dans-dataverse-client-lib/pull/45 must first be merged.

# Notify
@DANS-KNAW/dataversedans
