### PR TITLE
DD-1485 Support for configurable httpclient for dans-dataverse-client-lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans</groupId>
         <artifactId>dd-parent</artifactId>
-        <version>0.23.0</version>
+        <version>0.25.0-SNAPSHOT</version>
         <relativePath />
     </parent>
     <artifactId>dans-java-utils</artifactId>
@@ -36,6 +36,11 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-client</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans</groupId>
         <artifactId>dd-parent</artifactId>
-        <version>0.25.0-SNAPSHOT</version>
+        <version>0.25.0</version>
         <relativePath />
     </parent>
     <artifactId>dans-java-utils</artifactId>

--- a/src/main/java/nl/knaw/dans/lib/util/DataverseClientFactory.java
+++ b/src/main/java/nl/knaw/dans/lib/util/DataverseClientFactory.java
@@ -15,10 +15,15 @@
  */
 package nl.knaw.dans.lib.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.client.HttpClientBuilder;
+import io.dropwizard.client.HttpClientConfiguration;
+import io.dropwizard.core.setup.Environment;
 import lombok.Getter;
 import lombok.Setter;
 import nl.knaw.dans.lib.dataverse.DataverseClient;
 import nl.knaw.dans.lib.dataverse.DataverseClientConfig;
+import org.apache.hc.client5.http.classic.HttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,8 +41,9 @@ public class DataverseClientFactory {
     private int awaitLockStateMillisecondsBetweenRetries = 500;
     private int awaitIndexingMaxNumberOfRetries = 15;
     private int awaitIndexingMillisecondsBetweenRetries = 1000;
+    private HttpClientConfiguration httpClient = new HttpClientConfiguration();
 
-    public DataverseClient build() {
+    public DataverseClient build(Environment environment) {
         DataverseClientConfig config = new DataverseClientConfig(
             baseUrl,
             apiKey,
@@ -46,6 +52,8 @@ public class DataverseClientFactory {
             awaitIndexingMaxNumberOfRetries,
             awaitIndexingMillisecondsBetweenRetries,
             unblockKey);
-        return new DataverseClient(config);
+
+        return new DataverseClient(config, new HttpClientBuilder(environment).using(httpClient).build(httpClient.getUserAgent().toString()), environment.getObjectMapper());
     }
+
 }

--- a/src/main/java/nl/knaw/dans/lib/util/DataverseClientFactory.java
+++ b/src/main/java/nl/knaw/dans/lib/util/DataverseClientFactory.java
@@ -23,7 +23,7 @@ import lombok.Getter;
 import lombok.Setter;
 import nl.knaw.dans.lib.dataverse.DataverseClient;
 import nl.knaw.dans.lib.dataverse.DataverseClientConfig;
-import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +43,11 @@ public class DataverseClientFactory {
     private int awaitIndexingMillisecondsBetweenRetries = 1000;
     private HttpClientConfiguration httpClient = new HttpClientConfiguration();
 
-    public DataverseClient build(Environment environment) {
+    public DataverseClient build() {
+        return build(null, null);
+    }
+
+    public DataverseClient build(Environment environment, String name) {
         DataverseClientConfig config = new DataverseClientConfig(
             baseUrl,
             apiKey,
@@ -53,7 +57,14 @@ public class DataverseClientFactory {
             awaitIndexingMillisecondsBetweenRetries,
             unblockKey);
 
-        return new DataverseClient(config, new HttpClientBuilder(environment).using(httpClient).build(httpClient.getUserAgent().toString()), environment.getObjectMapper());
+        if (environment == null) {
+            return new DataverseClient(config, HttpClients.createDefault(), new ObjectMapper());
+        }
+        else {
+            return new DataverseClient(config,
+                new HttpClientBuilder(environment).using(httpClient).build(name), // N.B. name must be unique in the Environment, otherwise the old connection will be overwritten
+                environment.getObjectMapper());
+        }
     }
 
 }


### PR DESCRIPTION
Fixes DD-1485

# Description of changes
Changed `DataverseClientFactory ` so that you can pass in a `HttpClientConfiguration` object that configures the httpclient5 client used in `DataverseClient`.


# Notify
@DANS-KNAW/dataversedans
