### PR TITLE
DD-1492. Moved VersionProvider from dd-data-vault-cli.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <relativePath />
     </parent>
     <artifactId>dans-java-utils</artifactId>
-    <version>0.11.1-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
     <name>DANS Java Utility Classes</name>
     <inceptionYear>2021</inceptionYear>
     <scm>

--- a/src/main/java/nl/knaw/dans/lib/util/CliVersionProvider.java
+++ b/src/main/java/nl/knaw/dans/lib/util/CliVersionProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.util;
+
+import picocli.CommandLine.IVersionProvider;
+
+public class CliVersionProvider implements IVersionProvider {
+    @Override
+    public String[] getVersion() throws Exception {
+        return new String[] { new VersionProvider().getVersion() };
+    }
+}

--- a/src/main/java/nl/knaw/dans/lib/util/UrnUuid.java
+++ b/src/main/java/nl/knaw/dans/lib/util/UrnUuid.java
@@ -37,7 +37,23 @@ public class UrnUuid {
         UUID.fromString(s.substring("urn:uuid:".length())); // throws IllegalArgumentException if not a valid UUID
         return new UrnUuid(URI.create(s));
     }
-
+    
+    public static UrnUuid fromUri(URI uri) {
+        if (!uri.getScheme().equals("urn") || !uri.getSchemeSpecificPart().startsWith("uuid:")) {
+            throw new IllegalArgumentException("Not a URN UUID: " + uri);
+        }
+        
+        // Check that the remainder is a valid UUID
+        try {
+            UUID.fromString(uri.getSchemeSpecificPart().substring("uuid:".length()));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Not a URN UUID: " + uri);
+        }
+        
+        return new UrnUuid(uri);
+    }
+    
+    
     @Override
     public String toString() {
         return urn.toString();

--- a/src/main/java/nl/knaw/dans/lib/util/VersionProvider.java
+++ b/src/main/java/nl/knaw/dans/lib/util/VersionProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.util;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public class VersionProvider {
+    public String getVersion() throws IOException {
+        try (InputStream inputStream = getClass().getResourceAsStream("/version.txt")) {
+            if (inputStream != null) {
+                return IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+            }
+            else {
+                throw new IllegalStateException("Version file not found");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes DD-1492

# Description of changes
* Moved VersionProvider here. This class can be used to help print version information about the CLI or service.
* Added `fromUri` to the UrnUuid class.



# Notify
@DANS-KNAW/core-systems
