### PR TITLE
DD-2244 Moved PollingTaskExecutor from dd-data-vault

### DIFF
--- a/src/main/java/nl/knaw/dans/lib/util/DataverseClientFactory.java
+++ b/src/main/java/nl/knaw/dans/lib/util/DataverseClientFactory.java
@@ -25,11 +25,9 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseClient;
 import nl.knaw.dans.lib.dataverse.DataverseClientConfig;
-import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 
 import java.net.URI;
-import java.text.MessageFormat;
 
 import static java.text.MessageFormat.format;
 

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.util.pollingtaskexec;
+
+import io.dropwizard.hibernate.UnitOfWork;
+import io.dropwizard.lifecycle.Managed;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A task executor that repeatedly polls a task source for new work items at a fixed interval and executes them using a provided task factory. This class is designed to manage the lifecycle of a
+ * polling process that retrieves tasks and executes them in a controlled manner.
+ *
+ * @param <R> the type of the task records returned by the task source
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class PollingTaskExecutor<R> implements Managed {
+    private final String name;
+    private final ScheduledExecutorService scheduler;
+    private final Duration pollingInterval;
+    private final TaskSource<R> taskSource;
+    private final TaskFactory<R> taskFactory;
+
+    private ScheduledFuture<?> future;
+
+    /**
+     * Copy constructor. The source executor must not be running.
+     *
+     * @param other the source executor
+     */
+    @SuppressWarnings("CopyConstructorMissesField") // future is not copied on purpose
+    public PollingTaskExecutor(PollingTaskExecutor<R> other) {
+        if (other.future != null) {
+            throw new IllegalArgumentException("Cannot copy a running executor");
+        }
+        this.name = other.name;
+        this.scheduler = other.scheduler;
+        this.pollingInterval = other.pollingInterval;
+        this.taskSource = other.taskSource;
+        this.taskFactory = other.taskFactory;
+    }
+
+    @Override
+    public void start() {
+        long delayMs = Math.max(0, pollingInterval.toMillis());
+        future = scheduler.scheduleWithFixedDelay(this::tick, 0, delayMs, TimeUnit.MILLISECONDS);
+        log.info("{} started; polling every {}", name, pollingInterval);
+    }
+
+    @Override
+    public void stop() {
+        if (future != null) {
+            future.cancel(false);
+        }
+        scheduler.shutdown();
+        log.info("{} stopped", name);
+    }
+
+    @UnitOfWork
+    public void tick() {
+        try {
+            Optional<R> next = taskSource.nextTask();
+            if (next.isEmpty()) {
+                return;
+            }
+            R record = next.get();
+            log.debug("{}: found next task record: {}", name, record);
+            Runnable task = taskFactory.create(record);
+            task.run();
+        }
+        catch (Exception e) {
+            log.error("{}: error while polling or running task", name, e);
+        }
+    }
+}

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
@@ -62,7 +62,7 @@ public class PollingTaskExecutor<R> implements Managed {
 
     @Override
     public void start() {
-        long delayMs = Math.max(0, pollingInterval.toMillis());
+        long delayMs = Math.max(1L, pollingInterval.toMillis());
         future = scheduler.scheduleWithFixedDelay(this::tick, 0, delayMs, TimeUnit.MILLISECONDS);
         log.info("{} started; polling every {}", name, pollingInterval);
     }

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
@@ -44,7 +44,8 @@ public class PollingTaskExecutor<R> implements Managed {
     private ScheduledFuture<?> future;
 
     /**
-     * Copy constructor. The source executor must not be running.
+     * Copy constructor. The source executor must not be running. The purpose of this constructor is only to be able to wrap a PollingTaskExecutor in a UnitOfWorkAwareProxy. In general, no copies
+     * should be created of a PollingTaskExecutor, and in particular should the schedular not be shared among PollingTaskExecutors.
      *
      * @param other the source executor
      */

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskFactory.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.util.pollingtaskexec;
+
+/**
+ * Factory interface for creating {@link Runnable} tasks from a given record.
+ * This interface allows the decoupling of task creation logic from task execution logic.
+ *
+ * @param <R> the type of the record used to create a {@link Runnable} task
+ */
+public interface TaskFactory<R> {
+    Runnable create(R record);
+}

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskSource.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskSource.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.util.pollingtaskexec;
+
+import java.util.Optional;
+
+/**
+ * Represents a source of tasks from which tasks can be fetched one at a time. Implementations of this interface are responsible for providing the logic to retrieve the next available task or
+ * returning an empty result if no tasks are available.
+ *
+ * @param <R> the type of the tasks managed by this source
+ */
+public interface TaskSource<R> {
+    Optional<R> nextTask();
+}

--- a/src/main/java/nl/knaw/dans/lib/util/ruleengine/RuleEngineImpl.java
+++ b/src/main/java/nl/knaw/dans/lib/util/ruleengine/RuleEngineImpl.java
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/src/test/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutorTest.java
+++ b/src/test/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutorTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.util.pollingtaskexec;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PollingTaskExecutorTest {
+
+    private ScheduledExecutorService scheduler;
+    private TaskSource<String> taskSource;
+    private TaskFactory<String> taskFactory;
+    private PollingTaskExecutor<String> executor;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        scheduler = mock(ScheduledExecutorService.class);
+        taskSource = mock(TaskSource.class);
+        taskFactory = mock(TaskFactory.class);
+        executor = new PollingTaskExecutor<>("test-executor", scheduler, Duration.ofMillis(100), taskSource, taskFactory);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void start_should_schedule_tick_with_fixed_delay() {
+        executor.start();
+
+        verify(scheduler).scheduleWithFixedDelay(any(Runnable.class), eq(0L), eq(100L), eq(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void stop_should_cancel_future_and_shutdown_scheduler() {
+        ScheduledFuture future = mock(ScheduledFuture.class);
+        when(scheduler.scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(future);
+
+        executor.start();
+        executor.stop();
+
+        verify(future).cancel(false);
+        verify(scheduler).shutdown();
+    }
+
+    @Test
+    void stop_without_start_should_only_shutdown_scheduler() {
+        executor.stop();
+
+        verify(scheduler).shutdown();
+    }
+
+    @Test
+    void tick_should_poll_source_create_task_and_run_it() {
+        String record = "test-record";
+        Runnable task = mock(Runnable.class);
+
+        when(taskSource.nextTask()).thenReturn(Optional.of(record));
+        when(taskFactory.create(record)).thenReturn(task);
+
+        executor.tick();
+
+        verify(taskSource).nextTask();
+        verify(taskFactory).create(record);
+        verify(task).run();
+    }
+
+    @Test
+    void tick_should_do_nothing_if_source_is_empty() {
+        when(taskSource.nextTask()).thenReturn(Optional.empty());
+
+        executor.tick();
+
+        verify(taskSource).nextTask();
+        verify(taskFactory, never()).create(any());
+    }
+
+    @Test
+    void tick_should_catch_and_log_exceptions() {
+        when(taskSource.nextTask()).thenThrow(new RuntimeException("test exception"));
+
+        // Should not throw exception
+        executor.tick();
+
+        verify(taskSource).nextTask();
+    }
+
+    @Test
+    void copy_constructor_should_copy_fields() {
+        PollingTaskExecutor<String> copy = new PollingTaskExecutor<>(executor);
+
+        // Verify it works as expected by running a tick on the copy
+        String record = "test-record";
+        Runnable task = mock(Runnable.class);
+        when(taskSource.nextTask()).thenReturn(Optional.of(record));
+        when(taskFactory.create(record)).thenReturn(task);
+
+        copy.tick();
+
+        verify(taskSource).nextTask();
+        verify(taskFactory).create(record);
+        verify(task).run();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void copy_constructor_should_throw_if_source_is_running() {
+        ScheduledFuture future = mock(ScheduledFuture.class);
+        when(scheduler.scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(future);
+
+        executor.start();
+
+        assertThatThrownBy(() -> new PollingTaskExecutor<>(executor))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot copy a running executor");
+    }
+}

--- a/src/test/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutorTest.java
+++ b/src/test/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutorTest.java
@@ -17,7 +17,6 @@ package nl.knaw.dans.lib.util.pollingtaskexec;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
 import java.time.Duration;
 import java.util.Optional;
@@ -25,12 +24,10 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
Fixes DD-2244

# Description of changes
* Moved `PollingTaskExecutor` and related classed from `dd-data-vault` to `dans-java-utils` because it is a generically useful class.
* Added a unit test.


# Notify
@DANS-KNAW/core-systems
