### PR TITLE
DD-2237 Made the PollingTaskExecutor more generic. Now, a task can be represe…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <relativePath />
     </parent>
     <artifactId>dans-java-utils</artifactId>
-    <version>2.11.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <name>DANS Java Utility Classes</name>
     <inceptionYear>2021</inceptionYear>
     <scm>

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/ExecutorServiceTaskScheduler.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/ExecutorServiceTaskScheduler.java
@@ -29,6 +29,6 @@ public class ExecutorServiceTaskScheduler implements TaskScheduler {
 
     @Override
     public void schedule(Runnable task) {
-        executorService.submit(task);
+        executorService.execute(task);
     }
 }

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/ExecutorServiceTaskScheduler.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/ExecutorServiceTaskScheduler.java
@@ -15,14 +15,19 @@
  */
 package nl.knaw.dans.lib.util.pollingtaskexec;
 
+import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import lombok.RequiredArgsConstructor;
+
+import java.util.concurrent.ExecutorService;
 
 @RequiredArgsConstructor
 public class ExecutorServiceTaskScheduler implements TaskScheduler {
-    private final java.util.concurrent.ExecutorService executorService;
+    private final ExecutorService executorService;
+    private final UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory;
 
     @Override
     public void schedule(Runnable task) {
-        executorService.submit(task);
+        var proxy = unitOfWorkAwareProxyFactory.create(Runnable.class, new Class[] { Runnable.class }, new Object[] { task });
+        executorService.submit(proxy);
     }
 }

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/ExecutorServiceTaskScheduler.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/ExecutorServiceTaskScheduler.java
@@ -15,31 +15,20 @@
  */
 package nl.knaw.dans.lib.util.pollingtaskexec;
 
-import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import lombok.RequiredArgsConstructor;
 
 import java.util.concurrent.ExecutorService;
 
 /**
  * A task scheduler implementation that schedules tasks for execution using an {@link ExecutorService}. This class allows for tasks to be executed asynchronously using the provided executor service.
- * If a {@link UnitOfWorkAwareProxyFactory} is provided, it will create a proxy for the task to ensure that it is executed within a unit of work context, which is useful for tasks that interact with a
- * database using Hibernate. If no proxy factory is provided, tasks will be executed directly without any additional context management.
  *
  */
 @RequiredArgsConstructor
 public class ExecutorServiceTaskScheduler implements TaskScheduler {
     private final ExecutorService executorService;
-    private final UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory;
-
-    public ExecutorServiceTaskScheduler(ExecutorService executorService) {
-        this(executorService, null);
-    }
 
     @Override
     public void schedule(Runnable task) {
-        if (unitOfWorkAwareProxyFactory != null) {
-            task = unitOfWorkAwareProxyFactory.create(Runnable.class, new Class[] { Runnable.class }, new Object[] { task });
-        }
         executorService.submit(task);
     }
 }

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/ExecutorServiceTaskScheduler.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/ExecutorServiceTaskScheduler.java
@@ -20,14 +20,26 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.concurrent.ExecutorService;
 
+/**
+ * A task scheduler implementation that schedules tasks for execution using an {@link ExecutorService}. This class allows for tasks to be executed asynchronously using the provided executor service.
+ * If a {@link UnitOfWorkAwareProxyFactory} is provided, it will create a proxy for the task to ensure that it is executed within a unit of work context, which is useful for tasks that interact with a
+ * database using Hibernate. If no proxy factory is provided, tasks will be executed directly without any additional context management.
+ *
+ */
 @RequiredArgsConstructor
 public class ExecutorServiceTaskScheduler implements TaskScheduler {
     private final ExecutorService executorService;
     private final UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory;
 
+    public ExecutorServiceTaskScheduler(ExecutorService executorService) {
+        this(executorService, null);
+    }
+
     @Override
     public void schedule(Runnable task) {
-        var proxy = unitOfWorkAwareProxyFactory.create(Runnable.class, new Class[] { Runnable.class }, new Object[] { task });
-        executorService.submit(proxy);
+        if (unitOfWorkAwareProxyFactory != null) {
+            task = unitOfWorkAwareProxyFactory.create(Runnable.class, new Class[] { Runnable.class }, new Object[] { task });
+        }
+        executorService.submit(task);
     }
 }

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/ExecutorServiceTaskScheduler.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/ExecutorServiceTaskScheduler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.util.pollingtaskexec;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ExecutorServiceTaskScheduler implements TaskScheduler {
+    private final java.util.concurrent.ExecutorService executorService;
+
+    @Override
+    public void schedule(Runnable task) {
+        executorService.submit(task);
+    }
+}

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/ImmediateTaskScheduler.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/ImmediateTaskScheduler.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.util.pollingtaskexec;
+
+public class ImmediateTaskScheduler implements TaskScheduler {
+    @Override
+    public void schedule(Runnable task) {
+        task.run();
+    }
+}

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
@@ -40,8 +40,13 @@ public class PollingTaskExecutor<R> implements Managed {
     private final Duration pollingInterval;
     private final TaskSource<R> taskSource;
     private final TaskFactory<R> taskFactory;
+    private final TaskScheduler taskScheduler;
 
     private ScheduledFuture<?> future;
+
+    public PollingTaskExecutor(String name, ScheduledExecutorService scheduler, Duration pollingInterval, TaskSource<R> taskSource, TaskFactory<R> taskFactory) {
+        this(name, scheduler, pollingInterval, taskSource, taskFactory, new ImmediateTaskScheduler());
+    }
 
     /**
      * Copy constructor. The source executor must not be running. The purpose of this constructor is only to be able to wrap a PollingTaskExecutor in a UnitOfWorkAwareProxy. In general, no copies
@@ -59,6 +64,7 @@ public class PollingTaskExecutor<R> implements Managed {
         this.pollingInterval = other.pollingInterval;
         this.taskSource = other.taskSource;
         this.taskFactory = other.taskFactory;
+        this.taskScheduler = other.taskScheduler;
     }
 
     @Override
@@ -86,7 +92,7 @@ public class PollingTaskExecutor<R> implements Managed {
             }
             log.debug("{}: found next task record(s): {}", name, inputs);
             Runnable task = taskFactory.create(inputs);
-            task.run();
+            taskScheduler.schedule(task);
         }
         catch (Exception e) {
             log.error("{}: error while polling or running task", name, e);

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class PollingTaskExecutor<R> implements Managed {
     private final String name;
-    private final ScheduledExecutorService scheduler;
+    private final ScheduledExecutorService scheduledExecutorService;
     private final Duration pollingInterval;
     private final TaskSource<R> taskSource;
     private final TaskFactory<R> taskFactory;
@@ -44,8 +44,8 @@ public class PollingTaskExecutor<R> implements Managed {
 
     private ScheduledFuture<?> future;
 
-    public PollingTaskExecutor(String name, ScheduledExecutorService scheduler, Duration pollingInterval, TaskSource<R> taskSource, TaskFactory<R> taskFactory) {
-        this(name, scheduler, pollingInterval, taskSource, taskFactory, new ImmediateTaskScheduler());
+    public PollingTaskExecutor(String name, ScheduledExecutorService scheduledExecutorService, Duration pollingInterval, TaskSource<R> taskSource, TaskFactory<R> taskFactory) {
+        this(name, scheduledExecutorService, pollingInterval, taskSource, taskFactory, new ImmediateTaskScheduler());
     }
 
     /**
@@ -60,7 +60,7 @@ public class PollingTaskExecutor<R> implements Managed {
             throw new IllegalArgumentException("Cannot copy a running executor");
         }
         this.name = other.name;
-        this.scheduler = other.scheduler;
+        this.scheduledExecutorService = other.scheduledExecutorService;
         this.pollingInterval = other.pollingInterval;
         this.taskSource = other.taskSource;
         this.taskFactory = other.taskFactory;
@@ -70,7 +70,7 @@ public class PollingTaskExecutor<R> implements Managed {
     @Override
     public void start() {
         long delayMs = Math.max(1L, pollingInterval.toMillis());
-        future = scheduler.scheduleWithFixedDelay(this::tick, 0, delayMs, TimeUnit.MILLISECONDS);
+        future = scheduledExecutorService.scheduleWithFixedDelay(this::tick, 0, delayMs, TimeUnit.MILLISECONDS);
         log.info("{} started; polling every {}", name, pollingInterval);
     }
 
@@ -79,7 +79,7 @@ public class PollingTaskExecutor<R> implements Managed {
         if (future != null) {
             future.cancel(false);
         }
-        scheduler.shutdown();
+        scheduledExecutorService.shutdown();
         log.info("{} stopped", name);
     }
 

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
@@ -83,10 +83,9 @@ public class PollingTaskExecutor<R> implements Managed {
         log.info("{} stopped", name);
     }
 
-    @UnitOfWork
     public void tick() {
         try {
-            List<R> inputs = taskSource.nextInputs();
+            List<R> inputs = getNextInputs();
             if (inputs.isEmpty()) {
                 return;
             }
@@ -97,5 +96,11 @@ public class PollingTaskExecutor<R> implements Managed {
         catch (Exception e) {
             log.error("{}: error while polling or running task", name, e);
         }
+    }
+
+    // Must be protected for UnitOfWork to function.
+    @UnitOfWork
+    protected List<R> getNextInputs() {
+        return taskSource.nextInputs();
     }
 }

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
@@ -50,7 +50,7 @@ public class PollingTaskExecutor<R> implements Managed {
 
     /**
      * Copy constructor. The source executor must not be running. The purpose of this constructor is only to be able to wrap a PollingTaskExecutor in a UnitOfWorkAwareProxy. In general, no copies
-     * should be created of a PollingTaskExecutor, and in particular should the schedular not be shared among PollingTaskExecutors.
+     * should be created of a PollingTaskExecutor, and in particular should the scheduler not be shared among PollingTaskExecutors.
      *
      * @param other the source executor
      */

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
@@ -89,7 +89,7 @@ public class PollingTaskExecutor<R> implements Managed {
             if (input.isEmpty()) {
                 return;
             }
-            log.debug("{}: found next task record: {}", name, input.get());
+            log.debug("{}: found next task input: {}", name, input.get());
             Runnable task = taskFactory.create(input.get());
             taskScheduler.schedule(task);
         }

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
-import java.util.Optional;
+import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -80,13 +80,12 @@ public class PollingTaskExecutor<R> implements Managed {
     @UnitOfWork
     public void tick() {
         try {
-            Optional<R> next = taskSource.nextTask();
-            if (next.isEmpty()) {
+            List<R> inputs = taskSource.nextInputs();
+            if (inputs.isEmpty()) {
                 return;
             }
-            R record = next.get();
-            log.debug("{}: found next task record: {}", name, record);
-            Runnable task = taskFactory.create(record);
+            log.debug("{}: found next task record(s): {}", name, inputs);
+            Runnable task = taskFactory.create(inputs);
             task.run();
         }
         catch (Exception e) {

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutor.java
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
-import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -85,12 +85,12 @@ public class PollingTaskExecutor<R> implements Managed {
 
     public void tick() {
         try {
-            List<R> inputs = getNextInputs();
-            if (inputs.isEmpty()) {
+            Optional<R> input = getNextInput();
+            if (input.isEmpty()) {
                 return;
             }
-            log.debug("{}: found next task record(s): {}", name, inputs);
-            Runnable task = taskFactory.create(inputs);
+            log.debug("{}: found next task record: {}", name, input.get());
+            Runnable task = taskFactory.create(input.get());
             taskScheduler.schedule(task);
         }
         catch (Exception e) {
@@ -100,7 +100,7 @@ public class PollingTaskExecutor<R> implements Managed {
 
     // Must be protected for UnitOfWork to function.
     @UnitOfWork
-    protected List<R> getNextInputs() {
-        return taskSource.nextInputs();
+    protected Optional<R> getNextInput() {
+        return taskSource.nextInput();
     }
 }

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskFactory.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskFactory.java
@@ -15,12 +15,14 @@
  */
 package nl.knaw.dans.lib.util.pollingtaskexec;
 
+import java.util.List;
+
 /**
- * Factory interface for creating {@link Runnable} tasks from a given record.
+ * Factory interface for creating {@link Runnable} tasks from a list of records.
  * This interface allows the decoupling of task creation logic from task execution logic.
  *
  * @param <R> the type of the record used to create a {@link Runnable} task
  */
 public interface TaskFactory<R> {
-    Runnable create(R record);
+    Runnable create(List<R> records);
 }

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskFactory.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskFactory.java
@@ -15,14 +15,12 @@
  */
 package nl.knaw.dans.lib.util.pollingtaskexec;
 
-import java.util.List;
-
 /**
- * Factory interface for creating {@link Runnable} tasks from a list of records.
+ * Factory interface for creating {@link Runnable} tasks from a record.
  * This interface allows the decoupling of task creation logic from task execution logic.
  *
  * @param <R> the type of the record used to create a {@link Runnable} task
  */
 public interface TaskFactory<R> {
-    Runnable create(List<R> records);
+    Runnable create(R record);
 }

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskScheduler.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskScheduler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.util.pollingtaskexec;
+
+public interface TaskScheduler {
+
+    /**
+     * Schedules the task for execution.
+     *
+     * @param task the task to schedule
+     */
+    void schedule(Runnable task);
+}

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskSource.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskSource.java
@@ -19,7 +19,8 @@ import java.util.List;
 
 /**
  * Represents a source of tasks from which tasks can be fetched. Implementations of this interface are responsible for providing the logic to retrieve the next available inputs that together represent
- * one task to be executed, returning an empty list if no tasks are available.
+ * one task to be executed, returning an empty list if no tasks are available. This method is run within a @UnitOfWork to ensure that any updates it makes to the database are visible by the resulting
+ * tasks.
  *
  * @param <R> the type of the tasks managed by this source
  */

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskSource.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskSource.java
@@ -15,15 +15,15 @@
  */
 package nl.knaw.dans.lib.util.pollingtaskexec;
 
-import java.util.List;
+import java.util.Optional;
 
 /**
- * Represents a source of tasks from which tasks can be fetched. Implementations of this interface are responsible for providing the logic to retrieve the next available inputs that together represent
- * one task to be executed, returning an empty list if no tasks are available. This method is run within a @UnitOfWork to ensure that any updates it makes to the database are visible by the resulting
- * tasks.
+ * Represents a source of tasks from which tasks can be fetched. Implementations of this interface are responsible for providing the logic to retrieve the next available input that represents one
+ * task to be executed, returning an empty Optional if no tasks are available. This method is run within a @UnitOfWork to ensure that any updates it makes to the database are visible by the
+ * resulting tasks.
  *
  * @param <R> the type of the tasks managed by this source
  */
 public interface TaskSource<R> {
-    List<R> nextInputs();
+    Optional<R> nextInput();
 }

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskSource.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskSource.java
@@ -19,8 +19,8 @@ import java.util.Optional;
 
 /**
  * Represents a source of tasks from which tasks can be fetched. Implementations of this interface are responsible for providing the logic to retrieve the next available input that represents one
- * task to be executed, returning an empty Optional if no tasks are available. This method is run within a @UnitOfWork to ensure that any updates it makes to the database are visible by the
- * resulting tasks.
+ * task to be executed, returning an empty Optional if no tasks are available. When invoked by {@code PollingTaskExecutor}, this method is run within a {@code @UnitOfWork} so that any updates it
+ * makes to the database are visible to the resulting tasks.
  *
  * @param <R> the type of the input used to create or schedule a task
  */

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskSource.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskSource.java
@@ -22,7 +22,7 @@ import java.util.Optional;
  * task to be executed, returning an empty Optional if no tasks are available. This method is run within a @UnitOfWork to ensure that any updates it makes to the database are visible by the
  * resulting tasks.
  *
- * @param <R> the type of the tasks managed by this source
+ * @param <R> the type of the input used to create or schedule a task
  */
 public interface TaskSource<R> {
     Optional<R> nextInput();

--- a/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskSource.java
+++ b/src/main/java/nl/knaw/dans/lib/util/pollingtaskexec/TaskSource.java
@@ -15,14 +15,14 @@
  */
 package nl.knaw.dans.lib.util.pollingtaskexec;
 
-import java.util.Optional;
+import java.util.List;
 
 /**
- * Represents a source of tasks from which tasks can be fetched one at a time. Implementations of this interface are responsible for providing the logic to retrieve the next available task or
- * returning an empty result if no tasks are available.
+ * Represents a source of tasks from which tasks can be fetched. Implementations of this interface are responsible for providing the logic to retrieve the next available inputs that together represent
+ * one task to be executed, returning an empty list if no tasks are available.
  *
  * @param <R> the type of the tasks managed by this source
  */
 public interface TaskSource<R> {
-    Optional<R> nextTask();
+    List<R> nextInputs();
 }

--- a/src/test/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutorTest.java
+++ b/src/test/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutorTest.java
@@ -19,8 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.Collections;
-import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -81,37 +80,36 @@ class PollingTaskExecutorTest {
     @Test
     void tick_should_poll_source_create_task_and_run_it() {
         String record = "test-record";
-        List<String> records = Collections.singletonList(record);
         Runnable task = mock(Runnable.class);
 
-        when(taskSource.nextInputs()).thenReturn(records);
-        when(taskFactory.create(records)).thenReturn(task);
+        when(taskSource.nextInput()).thenReturn(Optional.of(record));
+        when(taskFactory.create(record)).thenReturn(task);
 
         executor.tick();
 
-        verify(taskSource).nextInputs();
-        verify(taskFactory).create(records);
+        verify(taskSource).nextInput();
+        verify(taskFactory).create(record);
         verify(task).run();
     }
 
     @Test
     void tick_should_do_nothing_if_source_is_empty() {
-        when(taskSource.nextInputs()).thenReturn(Collections.emptyList());
+        when(taskSource.nextInput()).thenReturn(Optional.empty());
 
         executor.tick();
 
-        verify(taskSource).nextInputs();
+        verify(taskSource).nextInput();
         verify(taskFactory, never()).create(any());
     }
 
     @Test
     void tick_should_catch_and_log_exceptions() {
-        when(taskSource.nextInputs()).thenThrow(new RuntimeException("test exception"));
+        when(taskSource.nextInput()).thenThrow(new RuntimeException("test exception"));
 
         // Should not throw exception
         executor.tick();
 
-        verify(taskSource).nextInputs();
+        verify(taskSource).nextInput();
     }
 
     @Test
@@ -120,15 +118,14 @@ class PollingTaskExecutorTest {
 
         // Verify it works as expected by running a tick on the copy
         String record = "test-record";
-        List<String> records = Collections.singletonList(record);
         Runnable task = mock(Runnable.class);
-        when(taskSource.nextInputs()).thenReturn(records);
-        when(taskFactory.create(records)).thenReturn(task);
+        when(taskSource.nextInput()).thenReturn(Optional.of(record));
+        when(taskFactory.create(record)).thenReturn(task);
 
         copy.tick();
 
-        verify(taskSource).nextInputs();
-        verify(taskFactory).create(records);
+        verify(taskSource).nextInput();
+        verify(taskFactory).create(record);
         verify(task).run();
     }
 

--- a/src/test/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutorTest.java
+++ b/src/test/java/nl/knaw/dans/lib/util/pollingtaskexec/PollingTaskExecutorTest.java
@@ -19,7 +19,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.Optional;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -80,36 +81,37 @@ class PollingTaskExecutorTest {
     @Test
     void tick_should_poll_source_create_task_and_run_it() {
         String record = "test-record";
+        List<String> records = Collections.singletonList(record);
         Runnable task = mock(Runnable.class);
 
-        when(taskSource.nextTask()).thenReturn(Optional.of(record));
-        when(taskFactory.create(record)).thenReturn(task);
+        when(taskSource.nextInputs()).thenReturn(records);
+        when(taskFactory.create(records)).thenReturn(task);
 
         executor.tick();
 
-        verify(taskSource).nextTask();
-        verify(taskFactory).create(record);
+        verify(taskSource).nextInputs();
+        verify(taskFactory).create(records);
         verify(task).run();
     }
 
     @Test
     void tick_should_do_nothing_if_source_is_empty() {
-        when(taskSource.nextTask()).thenReturn(Optional.empty());
+        when(taskSource.nextInputs()).thenReturn(Collections.emptyList());
 
         executor.tick();
 
-        verify(taskSource).nextTask();
+        verify(taskSource).nextInputs();
         verify(taskFactory, never()).create(any());
     }
 
     @Test
     void tick_should_catch_and_log_exceptions() {
-        when(taskSource.nextTask()).thenThrow(new RuntimeException("test exception"));
+        when(taskSource.nextInputs()).thenThrow(new RuntimeException("test exception"));
 
         // Should not throw exception
         executor.tick();
 
-        verify(taskSource).nextTask();
+        verify(taskSource).nextInputs();
     }
 
     @Test
@@ -118,14 +120,15 @@ class PollingTaskExecutorTest {
 
         // Verify it works as expected by running a tick on the copy
         String record = "test-record";
+        List<String> records = Collections.singletonList(record);
         Runnable task = mock(Runnable.class);
-        when(taskSource.nextTask()).thenReturn(Optional.of(record));
-        when(taskFactory.create(record)).thenReturn(task);
+        when(taskSource.nextInputs()).thenReturn(records);
+        when(taskFactory.create(records)).thenReturn(task);
 
         copy.tick();
 
-        verify(taskSource).nextTask();
-        verify(taskFactory).create(record);
+        verify(taskSource).nextInputs();
+        verify(taskFactory).create(records);
         verify(task).run();
     }
 


### PR DESCRIPTION
Fixes DD-2237

# Description of changes
Changes to support DD-2237. Introduced a `TaskScheduler` interface that lets clients configure how tasks picked up by `PollingTaskExecutor` and created by `TaskFactory` are then scheduled (e.g., immediately executed or submitted to an executorservice).

Made sure the nextInput is called in its own db-transaction, so that a status update to the underlying record is not lost if the task execution fails.

# Notify
@DANS-KNAW/core-systems
